### PR TITLE
Improve TravisCI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,15 @@
 language: elixir
+elixir:
+  - "1.4.1"
+otp_release:
+  - "18.0"
 sudo: false
+before_script:
+  - nvm install 6.2 && nvm use 6.2
+  - bin/setup-ci
+script: "mix test"
+cache:
+  directories:
+  - "deps"
+notifications:
+  email: false

--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,9 @@
 # Exit if any subcommand fails
 set -e
 
+echo "Removing previous build artifacts"
+rm -rf deps _build
+
 # check if phantomjs is installed
 if ! command -v phantomjs >/dev/null; then
   echo "You must install PhantomJS 2.x before continuing."
@@ -17,9 +20,6 @@ else
   fi
 fi
 
-echo "Removing previous build artifacts"
-rm -rf deps _build
-
 # Set up Elixir and Phoenix
 if ! command -v mix >/dev/null; then
   echo "It looks like you don't have Elixir installed."
@@ -27,12 +27,8 @@ if ! command -v mix >/dev/null; then
   exit 1
 fi
 
-echo "Installing dependencies and compiling"
-mix local.rebar
-mix deps.get
-mix deps.compile
-mix compile
+source bin/setup-ci
 
-echo "Configuring database"
-mix ecto.create
-mix ecto.migrate
+# Only if this isn't CI
+if [ -z "$CI" ]; then
+fi

--- a/bin/setup-ci
+++ b/bin/setup-ci
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+# Exit if any subcommand fails
+set -e
+
+echo "Installing dependencies and compiling"
+mix local.rebar --force
+mix local.hex --force
+mix deps.get
+mix deps.compile
+mix compile --warnings-as-errors
+
+echo "Configuring database"
+mix ecto.create
+mix ecto.migrate
+
+# Grab JS dependencies from NPM
+echo "Installing npm dependencies"
+npm install


### PR DESCRIPTION
This commit breaks out a separate `setup-ci` script, which `setup`
shells out to.

The intent is to provide a more focussed script that CI will run that
isn't concerned with user-facing warnings and `dev`-specific code.

Specify:

* Elixir, Postgres, OTP versions
* How to configure the CI environment
* How to execute the test suite
* A recent version of Node.js