### PR TITLE
Sanitize URL string before redirection

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+mix phoenix.server

--- a/test/models/mapped_url_test.exs
+++ b/test/models/mapped_url_test.exs
@@ -20,6 +20,14 @@ defmodule Urito.MappedUrlTest do
     assert {:slug, { "has already been taken", []}} in changeset.errors
   end
 
+  test ".get_by_slug!" do
+    mapped_url = insert(:mapped_url, slug: "foo-bar")
+
+    record = MappedUrl.get_by_slug!(" fOo-BaR \t")
+
+    assert mapped_url == record
+  end
+
   defp changeset_for(attributes) do
     params = params_for(:mapped_url, attributes)
 

--- a/web/controllers/redirection_controller.ex
+++ b/web/controllers/redirection_controller.ex
@@ -3,7 +3,7 @@ defmodule Urito.RedirectionController do
   alias Urito.MappedUrl
 
   def show(conn, %{"slug" => slug}) do
-    mapped_url = Repo.get_by!(MappedUrl, slug: slug)
+    mapped_url = MappedUrl.get_by_slug!(slug)
 
     redirect(conn, external: mapped_url.source)
   end

--- a/web/models/mapped_url.ex
+++ b/web/models/mapped_url.ex
@@ -1,4 +1,5 @@
 defmodule Urito.MappedUrl do
+  alias Urito.Repo
   use Urito.Web, :model
 
   schema "mapped_urls" do
@@ -6,6 +7,12 @@ defmodule Urito.MappedUrl do
     field :source, :string
 
     timestamps()
+  end
+
+  def get_by_slug!(slug) do
+    sanitized_slug = String.trim(slug)
+
+    Repo.get_by!(__MODULE__, slug: sanitized_slug)
   end
 
   def changeset(model \\ %__MODULE__{}, params \\ %{}) do


### PR DESCRIPTION
The slug might have whitespace or incorrect character casing.

Modify the `MappedUrl` model to find records by `slug` in a
whitespace and case-insensitive manner.