### PR TITLE
Implement Request Tracking

### DIFF
--- a/priv/repo/migrations/20170217154432_create_request.exs
+++ b/priv/repo/migrations/20170217154432_create_request.exs
@@ -1,0 +1,12 @@
+defmodule Urito.Repo.Migrations.CreateRequest do
+  use Ecto.Migration
+
+  def change do
+    create table(:requests) do
+      add :mapped_url_id, references(:mapped_urls, on_delete: :delete_all), null: false
+
+      timestamps()
+    end
+    create index(:requests, [:mapped_url_id])
+  end
+end

--- a/test/acceptance/tracks_redirects_test.exs
+++ b/test/acceptance/tracks_redirects_test.exs
@@ -1,0 +1,14 @@
+defmodule Urito.TracksRedirectTest do
+  use Urito.AcceptanceCase, async: true
+
+  test "tracks the redirection", %{session: session} do
+    mapped_url = insert(:mapped_url)
+
+    session
+    |> visit(redirection_path(Endpoint, :show, mapped_url.slug))
+    |> visit(mapped_url_path(Endpoint, :index))
+    |> click_link("Statistics")
+
+    assert find(session, "[data-role=statistics]") |> has_text?("1")
+  end
+end

--- a/test/models/request_model_test.exs
+++ b/test/models/request_model_test.exs
@@ -1,0 +1,13 @@
+defmodule Urito.RequestModelTest do
+  use Urito.ModelCase
+
+  alias Urito.Request
+
+  test "validations" do
+    invalid_attributes = %{mapped_url_id: nil}
+
+    assert [
+      {:mapped_url_id, "can't be blank"},
+    ] == errors_on(%Request{}, invalid_attributes)
+  end
+end

--- a/test/models/statistics_test.exs
+++ b/test/models/statistics_test.exs
@@ -1,0 +1,19 @@
+defmodule Urito.RequestTest do
+  use Urito.ModelCase
+
+  alias Urito.Statistics
+
+  test ".build/1" do
+    mapped_url = insert(:mapped_url)
+    insert(:request, mapped_url: mapped_url)
+
+    statistics = mapped_url
+                 |> Repo.preload(:requests)
+                 |> Statistics.build
+
+    assert %Statistics{
+      slug: mapped_url.slug,
+      views: 1,
+    } == statistics
+  end
+end

--- a/test/support/acceptance_case.ex
+++ b/test/support/acceptance_case.ex
@@ -6,6 +6,7 @@ defmodule Urito.AcceptanceCase do
       use Wallaby.DSL
 
       alias Urito.Endpoint
+      import Urito.Factory
       import Urito.Router.Helpers
 
       Application.put_env(:wallaby, :base_url, Urito.Endpoint.url)

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -1,6 +1,12 @@
 defmodule Urito.Factory do
   use ExMachina.Ecto, repo: Urito.Repo
 
+  def request_factory do
+    %Urito.Request{
+      mapped_url: build(:mapped_url),
+    }
+  end
+
   def mapped_url_factory do
     %Urito.MappedUrl{
       source: "https://example.com",

--- a/web/controllers/mapped_url_controller.ex
+++ b/web/controllers/mapped_url_controller.ex
@@ -24,7 +24,7 @@ defmodule Urito.MappedUrlController do
   end
 
   def index(conn, _params) do
-    mapped_urls = Repo.all(MappedUrl)
+    mapped_urls = MappedUrl |> Repo.all
 
     render(conn, "index.html", mapped_urls: mapped_urls)
   end

--- a/web/controllers/redirection_controller.ex
+++ b/web/controllers/redirection_controller.ex
@@ -1,9 +1,14 @@
 defmodule Urito.RedirectionController do
   use Urito.Web, :controller
   alias Urito.MappedUrl
+  alias Urito.Request
 
   def show(conn, %{"slug" => slug}) do
     mapped_url = MappedUrl.get_by_slug!(slug)
+
+    mapped_url
+    |> Request.changeset_for_tracking
+    |> Repo.insert!
 
     redirect(conn, external: mapped_url.source)
   end

--- a/web/controllers/statistics_controller.ex
+++ b/web/controllers/statistics_controller.ex
@@ -1,0 +1,14 @@
+defmodule Urito.StatisticsController do
+  use Urito.Web, :controller
+  alias Urito.MappedUrl
+  alias Urito.Statistics
+
+  def index(conn, %{"mapped_url_id" => mapped_url_id}) do
+    statistics = MappedUrl
+                 |> Repo.get!(mapped_url_id)
+                 |> Repo.preload(:requests)
+                 |> Statistics.build
+
+    render conn, "index.html", statistics: statistics
+  end
+end

--- a/web/models/mapped_url.ex
+++ b/web/models/mapped_url.ex
@@ -1,10 +1,12 @@
 defmodule Urito.MappedUrl do
   alias Urito.Repo
+  alias Urito.Request
   use Urito.Web, :model
 
   schema "mapped_urls" do
     field :slug, :string
     field :source, :string
+    has_many :requests, Request
 
     timestamps()
   end

--- a/web/models/request.ex
+++ b/web/models/request.ex
@@ -1,0 +1,25 @@
+defmodule Urito.Request do
+  alias Urito.MappedUrl
+  use Urito.Web, :model
+
+  schema "requests" do
+    belongs_to :mapped_url, MappedUrl
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:mapped_url_id])
+    |> validate_required([:mapped_url_id])
+  end
+
+  def changeset_for_tracking(mapped_url) do
+    %__MODULE__{
+      mapped_url_id: mapped_url.id,
+    }
+  end
+end

--- a/web/models/statistics.ex
+++ b/web/models/statistics.ex
@@ -1,0 +1,10 @@
+defmodule Urito.Statistics do
+  defstruct slug: "", views: 0
+
+  def build(mapped_url) do
+    %__MODULE__{
+      slug: mapped_url.slug,
+      views: Enum.count(mapped_url.requests),
+    }
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -12,7 +12,9 @@ defmodule Urito.Router do
   scope "/", Urito do
     pipe_through :browser
 
-    resources "/urls", MappedUrlController, only: [:new, :create, :index]
+    resources "/urls", MappedUrlController, only: [:new, :create, :index] do
+      resources "/statistics", StatisticsController, only: [:index]
+    end
     get "/", MappedUrlController, :index
     get "/:slug", RedirectionController, :show
   end

--- a/web/templates/mapped_url/index.html.eex
+++ b/web/templates/mapped_url/index.html.eex
@@ -4,25 +4,39 @@
   Shorten a URL!
 <% end %>
 
-<dl data-role="mapped-urls">
-  <%= for mapped_url <- @mapped_urls do %>
-    <dt>Shortened:</dt>
-    <dd>
-      <%= link to: redirection_url(@conn, :show, mapped_url.slug) do %>
-        <%= redirection_url(@conn, :show, mapped_url.slug) %>
-      <% end %>
-    </dd>
-
-    <dt>Slug:</dt>
-    <dd>
-      <%= mapped_url.slug %>
-    </dd>
-
-    <dt>Source:</dt>
-    <dd>
-      <%= link to: mapped_url.source do %>
-        <%= mapped_url.source %>
-      <% end %>
-    </dd>
-  <% end %>
-</dl>
+<table data-role="mapped-urls">
+  <thead>
+    <tr>
+      <th></th>
+      <th>Source:</th>
+      <th>Shortened:</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= for mapped_url <- @mapped_urls do %>
+      <tr>
+        <td>
+          <%= mapped_url.slug %>
+        </td>
+        <td>
+          <%= link to: mapped_url.source do %>
+            <%= mapped_url.source %>
+          <% end %>
+        </td>
+        <td>
+          <%= link to: redirection_url(@conn, :show, mapped_url.slug) do %>
+            <%= redirection_url(@conn, :show, mapped_url.slug) %>
+          <% end %>
+        </td>
+        <td>
+          <%= link(
+            to: mapped_url_statistics_path(@conn, :index, mapped_url.id),
+          ) do %>
+            Statistics
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/web/templates/statistics/index.html.eex
+++ b/web/templates/statistics/index.html.eex
@@ -1,0 +1,6 @@
+<h1>Statistics for /<%= @statistics.slug %></h1>
+
+<dl data-role="statistics">
+  <dt>Views</dt>
+  <dd><%= @statistics.views %></dd>
+</dl>

--- a/web/views/statistics_view.ex
+++ b/web/views/statistics_view.ex
@@ -1,0 +1,3 @@
+defmodule Urito.StatisticsView do
+  use Urito.Web, :view
+end


### PR DESCRIPTION
When a request is made to a shortened URL, (i.e. `uri.to/abcd123`),
create a `requests` row and associate it with the MappedUrl.

This commit also introduces the `Statistics` model, which isn't backed
by the database. It is responsible for calculating statistics for each
URL. Currently, its only stat is a count of views, but it could track
popular referrers, most recent views, views by month, etc.