### PR TITLE
Graph Statistics with Chartkick

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -45,6 +45,7 @@ defmodule Urito.Mixfile do
      {:postgrex, ">= 0.0.0"},
      {:phoenix_html, "~> 2.6"},
      {:phoenix_live_reload, "~> 1.0", only: :dev},
+     {:chartkick, github: "buren/chartkick-ex"},
      {:good_times, "~> 1.1"},
      {:gettext, "~> 0.11"},
      {:cowboy, "~> 1.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{"certifi": {:hex, :certifi, "1.0.0", "1c787a85b1855ba354f0b8920392c19aa1d06b0ee1362f9141279620a5be2039", [:rebar3], []},
+  "chartkick": {:git, "https://github.com/buren/chartkick-ex.git", "6b5a22a63c527113fd76fd0c9b12e2dc379370ed", []},
   "combine": {:hex, :combine, "0.9.6", "8d1034a127d4cbf6924c8a5010d3534d958085575fa4d9b878f200d79ac78335", [:mix], []},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, optional: false]}]},
@@ -29,4 +30,5 @@
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
   "timex": {:hex, :timex, "3.1.13", "48b33162e3ec33e9a08fb5f98e3f3c19c3e328dded3156096c1969b77d33eef0", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
   "tzdata": {:hex, :tzdata, "0.5.10", "087e8dfe8c0283473115ad8ca6974b898ecb55ca5c725427a142a79593391e90", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]},
+  "uuid": {:hex, :uuid, "1.1.6", "4927232f244e69c6e255643014c2d639dad5b8313dc2a6976ee1c3724e6ca60d", [:mix], []},
   "wallaby": {:hex, :wallaby, "0.14.0", "476a97a7d592fbd0e3875337c02afeee1ae059e8247791d99b90286ad97917b0", [:mix], [{:httpoison, "~> 0.9", [hex: :httpoison, optional: false]}, {:poison, ">= 1.4.0", [hex: :poison, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}]}}

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -25,6 +25,7 @@ defmodule Urito.ConnCase do
       import Ecto.Changeset
       import Ecto.Query
 
+      import Urito.Time
       import Urito.Factory
       import Urito.Router.Helpers
 

--- a/test/views/statistics_view_test.exs
+++ b/test/views/statistics_view_test.exs
@@ -1,0 +1,27 @@
+defmodule Urito.StatisticsViewTest do
+  use Urito.ConnCase, async: true
+
+  import DateTime
+  import GoodTimes
+
+  alias Urito.StatisticsView
+
+  test "graph_data_for transforms Statistics into lists of lists" do
+    last_year = a_year_ago() |> cast!
+    today = now() |> cast!
+    next_year = a_year_from_now() |> cast!
+    statistics = [
+      %{month: last_year, requests_count: 5},
+      %{month: today, requests_count: 3},
+      %{month: next_year, requests_count: 1},
+    ]
+
+    graph_data = StatisticsView.to_chart_data(statistics)
+
+    assert graph_data == [
+      [to_date(last_year), 5],
+      [to_date(today), 3],
+      [to_date(next_year), 1],
+    ]
+  end
+end

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -9,6 +9,7 @@
 
     <title>uri.to: a URL shortener</title>
     <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
+    <%= render_existing @view_module, "scripts.html", assigns %>
   </head>
 
   <body>
@@ -21,6 +22,7 @@
       </main>
 
     </div> <!-- /container -->
+
     <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
   </body>
 </html>

--- a/web/templates/statistics/index.html.eex
+++ b/web/templates/statistics/index.html.eex
@@ -4,6 +4,13 @@
   Back
 <% end %>
 
+<%= @mapped_url.statistics
+    |> to_chart_data
+    |> to_json
+    |> Chartkick.line_chart
+    |> raw
+%>
+
 <dl data-role="statistics">
   <table>
     <thead>

--- a/web/views/statistics_view.ex
+++ b/web/views/statistics_view.ex
@@ -1,9 +1,24 @@
 defmodule Urito.StatisticsView do
   use Urito.Web, :view
-  use Timex
 
   def format_month(datetime) do
     datetime
     |> Timex.format!("%B %Y", :strftime)
+  end
+
+  def to_chart_data(statistics) do
+    statistics
+    |> Enum.map(fn s -> [Timex.to_date(s.month), s.requests_count] end)
+  end
+
+  def to_json(object) do
+    Poison.encode!(object)
+  end
+
+  def render("scripts.html", _assigns) do
+    ~E(
+       <script src="//www.google.com/jsapi"></script>
+       <script src="https://cdnjs.cloudflare.com/ajax/libs/chartkick/2.2.3/chartkick.min.js"></script>
+     )
   end
 end


### PR DESCRIPTION
In addition to a `<table>` or page view statistics, render a line graph
to show how shortened URL is visited over time.

<img width="467" alt="screen shot 2017-03-10 at 1 28 10 pm" src="https://cloud.githubusercontent.com/assets/2575027/23807884/7d99dc9c-0595-11e7-96da-687908ba6989.png">
